### PR TITLE
Read or Write only property serialization

### DIFF
--- a/Source/Reflection/fsMetaProperty.cs
+++ b/Source/Reflection/fsMetaProperty.cs
@@ -6,16 +6,24 @@ namespace FullSerializer.Internal {
     /// A property or field on a MetaType.
     /// </summary>
     public class fsMetaProperty {
+		private readonly bool canRead;
+		private readonly bool canWrite;
+
         internal fsMetaProperty(FieldInfo field) {
             _memberInfo = field;
             StorageType = field.FieldType;
             Name = GetName(field);
+
+			canRead = canWrite = true;
         }
 
         internal fsMetaProperty(PropertyInfo property) {
             _memberInfo = property;
             StorageType = property.PropertyType;
             Name = GetName(property);
+
+			canRead = property.CanRead;
+			canWrite = property.CanWrite;
         }
 
         /// <summary>
@@ -40,6 +48,10 @@ namespace FullSerializer.Internal {
             private set;
         }
 
+		public bool CanWrite() {
+			return canWrite;
+		}
+
         /// <summary>
         /// Writes a value to the property that this MetaProperty represents, using given object
         /// instance as the context.
@@ -59,6 +71,10 @@ namespace FullSerializer.Internal {
                 }
             }
         }
+
+		public bool CanRead() {
+			return canRead;
+		}
 
         /// <summary>
         /// Reads a value from the property that this MetaProperty represents, using the given

--- a/Source/Reflection/fsMetaType.cs
+++ b/Source/Reflection/fsMetaType.cs
@@ -125,11 +125,6 @@ namespace FullSerializer {
                 return false;
             }
 
-            // If the property cannot be both read and written to, we cannot serialize it
-            if (property.CanRead == false || property.CanWrite == false) {
-                return false;
-            }
-
             var publicGetMethod = property.GetGetMethod(/*nonPublic:*/ false);
             var publicSetMethod = property.GetSetMethod(/*nonPublic:*/ false);
 


### PR DESCRIPTION
Read only and write only properties need to be serialized/deserialized in some cases.

For my current project, I am required to serialize read-only properties and deserialize write-only properties. 

This could either be default behaviour, or opt-in (through the config?), or as an annotation to the property, or both! :smile: 

This PR just demonstrates how it would work if it was the default behaviour.