### PR TITLE
Fixed string escaping of backslash character.

### DIFF
--- a/Source/fsJsonPrinter.cs
+++ b/Source/fsJsonPrinter.cs
@@ -70,7 +70,7 @@ namespace FullSerializer {
                 // standard escape character
                 switch (c) {
                     case '"': result.Append("\\\""); continue;
-                    case '\\': result.Append(@"\"); continue;
+                    case '\\': result.Append(@"\\"); continue;
                     case '\a': result.Append(@"\a"); continue;
                     case '\b': result.Append(@"\b"); continue;
                     case '\f': result.Append(@"\f"); continue;


### PR DESCRIPTION
Strings with a backslash in them were not escaped properly, causing serialization/de-serialization to fail.