### PR TITLE
allow /* comment */ in json parser

### DIFF
--- a/Source/fsJsonParser.cs
+++ b/Source/fsJsonParser.cs
@@ -60,16 +60,30 @@ namespace FullSerializer {
                     continue;
                 }
 
-                // comment? they begin with //
-                if (HasValue(1) &&
-                    (Character(0) == '/' && Character(1) == '/')) {
-
-                    // skip the rest of the line
-                    while (HasValue() && Environment.NewLine.Contains("" + Character()) == false) {
+                // comment?
+                if (HasValue(1) && Character(0) == '/') {
+                    if (Character(1) == '/') {
+                        // skip the rest of the line
+                        while (HasValue() && Environment.NewLine.Contains("" + Character()) == false) {
+                            TryMoveNext();
+                        }
+                        continue;
+                    } else if (Character(1) == '*') {
+                        // skip to comment close
                         TryMoveNext();
+                        TryMoveNext();
+                        while (HasValue(1)) {
+                            if (Character(0) == '*' && Character(1) == '/') {
+                                TryMoveNext();
+                                TryMoveNext();
+                                TryMoveNext();
+                                break;
+                            } else {
+                                TryMoveNext();
+                            }
+                        }
                     }
-
-                    // we still need to skip whitespace on the next line
+                    // let other checks to check fail
                     continue;
                 }
 

--- a/Testing/Editor/ParseTests.cs
+++ b/Testing/Editor/ParseTests.cs
@@ -210,5 +210,46 @@ namespace FullSerializer.Tests {
             fsData escapeRequired = new fsData(fsJsonPrinter.PrettyJson(data));
             Assert.AreEqual(escapeRequired, Parse(fsJsonPrinter.PrettyJson(escapeRequired)));
         }
+
+        [Test]
+        public void TestComment() {
+            string jsonString = @"
+                /* 
+                * comment
+                */
+                // comment
+                { 
+                    // comment
+                    /* comment */
+                    ""ls"": [
+                        1,
+                        // comment
+                        2,
+                        /* comment */
+                        3
+                    ],
+                    // comment
+                    ""obj"" : {
+                    // comment
+                    ""a"" : ""b"",
+                    // comment
+                    ""c"" : /*  comment  */
+                    ""d""
+                    // comment
+                    }  /* comment */
+                    // comment
+                }
+                /* comment */ // comment
+                ";
+            fsData data = new fsData(new Dictionary<string, fsData>() {
+                    {"ls", new fsData(new List<fsData> {new fsData(1), new fsData(2), new fsData(3)})},
+                    {"obj", new fsData(new Dictionary<string, fsData>() {
+                        {"a", new fsData("b")},
+                        {"c", new fsData("d")}
+                    })}
+                });
+            fsData parsedData = Parse(jsonString);
+            Assert.AreEqual(data, parsedData);
+        }
     }
 }


### PR DESCRIPTION
Hi Jacob.  
I've hacked the json parser a bit to allow `/**/` style comment, with a stupid test case attached. If you think this needs more work or you don't like this feature please let me know :)