### PR TITLE
make PropertiesProvider test pass

### DIFF
--- a/Testing/RuntimeTests/Providers/PrivateFieldsProvider.cs
+++ b/Testing/RuntimeTests/Providers/PrivateFieldsProvider.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using UnityEngine;
+using FullSerializer;
 
 public class PrivateHolder {
     public PrivateHolder() { }
@@ -9,10 +9,10 @@ public class PrivateHolder {
         SerializedProperty = 2;
     }
 
-    [SerializeField]
+    [fsProperty]
     private int SerializedField;
 
-    [SerializeField]
+    [fsProperty]
     private int SerializedProperty { get; set; }
 
     public override bool Equals(object obj) {

--- a/Testing/RuntimeTests/Providers/PropertiesProvider.cs
+++ b/Testing/RuntimeTests/Providers/PropertiesProvider.cs
@@ -1,6 +1,6 @@
-﻿using System;
+﻿using FullSerializer;
+using System;
 using System.Collections.Generic;
-using UnityEngine;
 
 public class PropertiesProvider : TestProvider<object> {
     public struct PublicGetPublicSet {
@@ -10,7 +10,7 @@ public class PropertiesProvider : TestProvider<object> {
 
     public struct PrivateGetPublicSet {
         public PrivateGetPublicSet(int value) : this() { Value = value; }
-        [SerializeField]
+        [fsProperty]
         public int Value { private get; set; }
 
         public static bool Compare(PrivateGetPublicSet a, PrivateGetPublicSet b) {

--- a/Testing/RuntimeTests/Providers/PropertiesProvider.cs
+++ b/Testing/RuntimeTests/Providers/PropertiesProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using UnityEngine;
 
 public class PropertiesProvider : TestProvider<object> {
     public struct PublicGetPublicSet {
@@ -9,6 +10,7 @@ public class PropertiesProvider : TestProvider<object> {
 
     public struct PrivateGetPublicSet {
         public PrivateGetPublicSet(int value) : this() { Value = value; }
+        [SerializeField]
         public int Value { private get; set; }
 
         public static bool Compare(PrivateGetPublicSet a, PrivateGetPublicSet b) {


### PR DESCRIPTION
Hi Jacob,

I'm trying out the tests and found this one can be easily fixed to pass.
The other one about DateTimeOffset is behaving differently in MS CLR and Mono so I'm leaving it alone.

Thanks!