### PR TITLE
- Added better Visual Studio support for Compiler Directives.

### DIFF
--- a/Source/Converters/fsIEnumerableConverter.cs
+++ b/Source/Converters/fsIEnumerableConverter.cs
@@ -47,7 +47,13 @@ namespace FullSerializer.Internal {
         }
 
         private bool IsStack(Type type) {
-            return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Stack<>);
+#if UNITY_METRO
+            return type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == typeof(Stack<>);
+#else
+           return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Stack<>);
+#endif
+
+
         }
 
         public override fsResult TryDeserialize(fsData data, ref object instance_, Type storageType) {

--- a/Source/Internal/fsPortableReflection.cs
+++ b/Source/Internal/fsPortableReflection.cs
@@ -50,7 +50,7 @@ namespace FullSerializer.Internal {
         }
 
         public static Attribute GetAttribute(Type type, Type attributeType) {
-            return GetAttribute(type.GetTypeInfo(), attributeType);
+            return GetAttribute(type.GetTypeInfo().AsType(), attributeType);
         }
 
         public static bool HasAttribute(Type type, Type attributeType) {

--- a/Source/fsISerializationCallbacks.cs
+++ b/Source/fsISerializationCallbacks.cs
@@ -1,5 +1,7 @@
 ﻿using System;
-
+#if !NO_UNITY
+using UnityEngine;
+#endif
 namespace FullSerializer {
     /// <summary>
     /// Extend this interface on your type to receive notifications about serialization/deserialization events. If you don't


### PR DESCRIPTION
- Fixed compiler fails due to WinRT having different access to Type methods/fields.
- Added some missing Compiler directive IF/ELSE cases, mainly if you want to use VIsual Studio 2015 as you won't always have direct access to UNITYENGINE unless you specifically reference it (which kills the NOUNITY option..which also in turn can kill some external Unit Test proj's in a different build process/workflow).