### PR TITLE
Fix ISerializationCallbackReceiver not found error

### DIFF
--- a/Source/fsISerializationCallbacks.cs
+++ b/Source/fsISerializationCallbacks.cs
@@ -1,4 +1,7 @@
-﻿using System;
+using System;
+#if !NO_UNITY
+using UnityEngine;
+#endif
 
 namespace FullSerializer {
     /// <summary>


### PR DESCRIPTION
Quick fix for the type error on importing the sources into Unity.

    error CS0246: The type or namespace name `ISerializationCallbackReceiver' could not be found. Are you missing a using directive or an assembly reference?

(#60 for reference)