### PR TITLE
Fixes: when using versioning, $ref refers to the old non-migrated version.

### DIFF
--- a/Source/fsSerializer.cs
+++ b/Source/fsSerializer.cs
@@ -658,6 +658,15 @@ namespace FullSerializer {
                         result = path[i].Migrate(result);
                     }
 
+					// Our data contained an object definition ($id) that was added to _references in step 4.
+					// However, in case we are doing versioning, it will contain the old version.
+					// To make sure future references to this object end up referencing the migrated version,
+					// we must update the reference.
+					if(IsObjectDefinition(data)) {
+						int sourceId = int.Parse(data.AsDictionary[Key_ObjectDefinition].AsString);
+						_references.AddReferenceWithId(sourceId,result);
+					}
+
                     processors = GetProcessors(deserializeResult.GetType());
                     return deserializeResult;
                 }

--- a/Source/fsSerializer.cs
+++ b/Source/fsSerializer.cs
@@ -658,14 +658,14 @@ namespace FullSerializer {
                         result = path[i].Migrate(result);
                     }
 
-					// Our data contained an object definition ($id) that was added to _references in step 4.
-					// However, in case we are doing versioning, it will contain the old version.
-					// To make sure future references to this object end up referencing the migrated version,
-					// we must update the reference.
-					if(IsObjectDefinition(data)) {
-						int sourceId = int.Parse(data.AsDictionary[Key_ObjectDefinition].AsString);
-						_references.AddReferenceWithId(sourceId,result);
-					}
+                    // Our data contained an object definition ($id) that was added to _references in step 4.
+                    // However, in case we are doing versioning, it will contain the old version.
+                    // To make sure future references to this object end up referencing the migrated version,
+                    // we must update the reference.
+                    if(IsObjectDefinition(data)) {
+                        int sourceId = int.Parse(data.AsDictionary[Key_ObjectDefinition].AsString);
+                        _references.AddReferenceWithId(sourceId, result);
+                    }
 
                     processors = GetProcessors(deserializeResult.GetType());
                     return deserializeResult;


### PR DESCRIPTION
When using versioning, $id works correctly but $refs still refer to the old version, because it is written to _references prior to being migrated.
This pull request updates the _references such that the migrated version ends up being used for $refs.