### PR TITLE
Fix crashes when [de]serializing null instances of types with callbacks

### DIFF
--- a/Assets/FullSerializer/Source/fsISerializationCallbacks.cs
+++ b/Assets/FullSerializer/Source/fsISerializationCallbacks.cs
@@ -49,10 +49,14 @@ namespace FullSerializer.Internal {
         }
 
         public override void OnBeforeSerialize(Type storageType, object instance) {
+            // Don't call the callback on null instances.
+            if(instance == null) return;
             ((fsISerializationCallbacks)instance).OnBeforeSerialize(storageType);
         }
 
         public override void OnAfterSerialize(Type storageType, object instance, ref fsData data) {
+            // Don't call the callback on null instances.
+            if(instance == null) return;
             ((fsISerializationCallbacks)instance).OnAfterSerialize(storageType, ref data);
         }
 
@@ -65,6 +69,8 @@ namespace FullSerializer.Internal {
         }
 
         public override void OnAfterDeserialize(Type storageType, object instance) {
+            // Don't call the callback on null instances.
+            if(instance == null) return;
             ((fsISerializationCallbacks)instance).OnAfterDeserialize(storageType);
         }
     }
@@ -76,13 +82,14 @@ namespace FullSerializer.Internal {
         }
 
         public override void OnBeforeSerialize(Type storageType, object instance) {
-            if (instance == null)
-                return;
-
+            // Don't call the callback on null instances.
+            if(instance == null) return;
             ((ISerializationCallbackReceiver)instance).OnBeforeSerialize();
         }
 
         public override void OnAfterDeserialize(Type storageType, object instance) {
+            // Don't call the callback on null instances.
+            if(instance == null) return;
             ((ISerializationCallbackReceiver)instance).OnAfterDeserialize();
         }
     }

--- a/Assets/FullSerializer/Testing/Editor/CallbackTests.cs
+++ b/Assets/FullSerializer/Testing/Editor/CallbackTests.cs
@@ -36,25 +36,31 @@ namespace FullSerializer.Tests.CallbackTests {
 
     public class CallbackTests {
         [Test]
-        public void TestSerializationCallbacks() {
-            {
-                var original = new StructModel();
-                var dup = Clone(original);
-                // not possible since we don't box original
-                //Assert.AreEqual(1, original.beforeSerialize);
-                //Assert.AreEqual(1, original.afterSerialize);
-                Assert.AreEqual(1, dup.beforeDeserialize);
-                Assert.AreEqual(1, dup.afterDeserialize);
-            }
+        public void TestSerializationCallbacksOnStruct() {
+            var original = new StructModel();
+            var dup = Clone(original);
+            // not possible since we don't box original
+            //Assert.AreEqual(1, original.beforeSerialize);
+            //Assert.AreEqual(1, original.afterSerialize);
+            Assert.AreEqual(1, dup.beforeDeserialize);
+            Assert.AreEqual(1, dup.afterDeserialize);
+        }
 
-            {
-                var original = new ClassModel();
-                var dup = Clone(original);
-                Assert.AreEqual(1, original.beforeSerialize);
-                Assert.AreEqual(1, original.afterSerialize);
-                Assert.AreEqual(1, dup.beforeDeserialize);
-                Assert.AreEqual(1, dup.afterDeserialize);
-            }
+        [Test]
+        public void TestSerializationCallbacksOnClass() {
+            var original = new ClassModel();
+            var dup = Clone(original);
+            Assert.AreEqual(1, original.beforeSerialize);
+            Assert.AreEqual(1, original.afterSerialize);
+            Assert.AreEqual(1, dup.beforeDeserialize);
+            Assert.AreEqual(1, dup.afterDeserialize);
+        }
+
+        [Test]
+        public void TestSerializationCallbacksOnNullInstances() {
+            ClassModel original = null;
+            var dup = Clone( original );
+            Assert.AreEqual( original, dup );
         }
 
         private T Clone<T>(T expected) {


### PR DESCRIPTION
Fix crashes when [de]serializing null instances of types with callbacks

Fix #80