### PR TITLE
Fix crash when serializing enums with uint underlying type

### DIFF
--- a/Assets/FullSerializer/Source/Converters/fsEnumConverter.cs
+++ b/Assets/FullSerializer/Source/Converters/fsEnumConverter.cs
@@ -35,7 +35,7 @@ namespace FullSerializer.Internal {
 
                 bool first = true;
                 foreach (var value in Enum.GetValues(storageType)) {
-                    int integralValue = (int)value;
+                    long integralValue = Convert.ToInt64(value);
                     bool isSet = (instanceValue & integralValue) != 0;
 
                     if (isSet) {

--- a/Assets/FullSerializer/Testing/Editor/EnumTests.cs
+++ b/Assets/FullSerializer/Testing/Editor/EnumTests.cs
@@ -11,14 +11,34 @@ namespace FullSerializer.Tests.EnumTest {
     }
 
     [Flags]
+    public enum DefinedFlagsUint : uint {
+        A = 1 << 0,
+        B = 1 << 1,
+        C = 1 << 5
+    }
+
+    [Flags]
     public enum RegularFlags {
         A,
         B,
         C
     }
 
+    [Flags]
+    public enum RegularFlagsUint : uint {
+        A,
+        B,
+        C
+    }
 
     public enum NotFlags {
+        A = 10,
+        B = 0,
+        C = 1,
+        D = 20
+    }
+
+    public enum NotFlagsUint : uint {
         A = 10,
         B = 0,
         C = 1,
@@ -53,6 +73,35 @@ namespace FullSerializer.Tests.EnumTest {
             DoTest(NotFlags.C);
             DoTest(NotFlags.D);
             DoTest(NotFlags.A & NotFlags.B);
+        }
+
+        [Test]
+        public void TestDefinedFlagsEnumUint() {
+            DoTest(DefinedFlagsUint.A);
+            DoTest(DefinedFlagsUint.B);
+            DoTest(DefinedFlagsUint.C);
+            DoTest(DefinedFlagsUint.A | DefinedFlagsUint.B);
+            DoTest(DefinedFlagsUint.A | DefinedFlagsUint.C);
+            DoTest(DefinedFlagsUint.A | DefinedFlagsUint.B | DefinedFlagsUint.C);
+        }
+
+        [Test]
+        public void TestRegularFlagsEnumUint() {
+            DoTest(RegularFlagsUint.A);
+            DoTest(RegularFlagsUint.B);
+            DoTest(RegularFlagsUint.C);
+            DoTest(RegularFlagsUint.A | RegularFlagsUint.B);
+            DoTest(RegularFlagsUint.A | RegularFlagsUint.C);
+            DoTest(RegularFlagsUint.A | RegularFlagsUint.B | RegularFlagsUint.C);
+        }
+
+        [Test]
+        public void TestEnumUint() {
+            DoTest(NotFlagsUint.A);
+            DoTest(NotFlagsUint.B);
+            DoTest(NotFlagsUint.C);
+            DoTest(NotFlagsUint.D);
+            DoTest(NotFlagsUint.A & NotFlagsUint.B);
         }
 
         private void DoTest<T>(T expected) {


### PR DESCRIPTION
Fix crash when serializing enums with uint underlying type

Add tests to demonstrate fix

Fix #82