### PR TITLE
Fix exception when serializing types with indexer properties

### DIFF
--- a/Assets/FullSerializer/Source/Reflection/fsMetaType.cs
+++ b/Assets/FullSerializer/Source/Reflection/fsMetaType.cs
@@ -133,6 +133,11 @@ namespace FullSerializer {
                 return false;
             }
 
+            // Never serialize indexers. I can't think of a sane way to serialize/deserialize them, and they're normally wrappers around other fields anyway...
+            if (property.GetIndexParameters().Length > 0) {
+                return false;
+            }
+
             // If a property is annotated with one of the serializable attributes, then it should
             // it should definitely be serialized.
             //

--- a/Assets/FullSerializer/Testing/Editor/IndexerTests.cs
+++ b/Assets/FullSerializer/Testing/Editor/IndexerTests.cs
@@ -1,0 +1,38 @@
+﻿using NUnit.Framework;
+
+namespace FullSerializer.Tests.IndexerTest {
+    public class IndexerTests {
+        class IndexerType {
+            private int[] arr = new int[2];
+
+            [fsProperty]
+            public int this[int i] {
+                get { return arr[i]; }
+                set { arr[i] = value; }
+            }
+        }
+
+        [Test]
+        public void TestIndexerType() {
+            var original = new IndexerType();
+            original[0] = 1;
+            original[1] = 5;
+            var dup = Clone(original);
+
+            // Silly test really; in an ideal world the below would succeed,
+            // but serializing indexers is very hard so instead we test that FullSerializer doesn't crash while processing types with indexers!
+            //Assert.AreEqual(original[0], dup[0]);
+            //Assert.AreEqual(original[1], dup[1]);
+
+            Assert.IsNotNull(dup);
+        }
+
+        private T Clone<T>(T expected) {
+            fsData serializedData;
+            new fsSerializer().TrySerialize(expected, out serializedData).AssertSuccessWithoutWarnings();
+            var actual = default(T);
+            new fsSerializer().TryDeserialize(serializedData, ref actual);
+            return actual;
+        }
+    }
+}

--- a/Assets/FullSerializer/Testing/Editor/IndexerTests.cs.meta
+++ b/Assets/FullSerializer/Testing/Editor/IndexerTests.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 274b80356efac474792adcd540f717c7
+timeCreated: 1455211036
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Fix exception when serializing types with indexer properties

They aren't serialized since that seems to be difficult or impossible,
instead I just explicitly ignore them.

Add tests to demonstrate the new behaviour

Fix #84