### PR TITLE
Fix exception when serializing float.NaN, and float infinities

### DIFF
--- a/Assets/FullSerializer/Source/Converters/fsPrimitiveConverter.cs
+++ b/Assets/FullSerializer/Source/Converters/fsPrimitiveConverter.cs
@@ -61,8 +61,12 @@ namespace FullSerializer.Internal {
                 // Casting from float to double introduces floating point jitter, ie, 0.1 becomes 0.100000001490116.
                 // Casting to decimal as an intermediate step removes the jitter. Not sure why.
                 if (instance.GetType() == typeof(float) &&
-                    // Decimal can't store float.MinValue/float.MaxValue - an exception gets thrown in that scenario.
-                    (float)instance != float.MinValue && (float)instance != float.MaxValue) {
+                    // Decimal can't store float.MinValue/float.MaxValue/float.PositiveInfinity/float.NegativeInfinity/float.NaN - an exception gets thrown in that scenario.
+                    (float)instance != float.MinValue &&
+                    (float)instance != float.MaxValue &&
+                    !float.IsInfinity((float)instance) &&
+                    !float.IsNaN((float)instance)
+                    ) {
                     serialized = new fsData((double)(decimal)(float)instance);
                     return fsResult.Success;
                 }

--- a/Assets/FullSerializer/Testing/Editor/FloatJitterTests.cs
+++ b/Assets/FullSerializer/Testing/Editor/FloatJitterTests.cs
@@ -16,5 +16,71 @@ namespace FullSerializer.Tests {
             serializer.TryDeserialize(data, ref deserialized).AssertSuccessWithoutWarnings();
             Assert.AreEqual(0.1f, deserialized);
         }
+
+        [Test]
+        public void VerifyNaNRoundTrips() {
+            var serializer = new fsSerializer();
+
+            // todo: could definitely reduce duplication of tests in this file!
+            fsData data;
+            serializer.TrySerialize(float.NaN, out data).AssertSuccessWithoutWarnings();
+            Assert.AreEqual("NaN", fsJsonPrinter.PrettyJson(data));
+
+            float deserialized = 0f;
+            serializer.TryDeserialize(data, ref deserialized).AssertSuccessWithoutWarnings();
+            Assert.AreEqual(float.NaN, deserialized);
+        }
+
+        [Test]
+        public void VerifyPositiveInfinityRoundTrips() {
+            var serializer = new fsSerializer();
+
+            fsData data;
+            serializer.TrySerialize(float.PositiveInfinity, out data).AssertSuccessWithoutWarnings();
+            Assert.AreEqual("Infinity", fsJsonPrinter.PrettyJson(data));
+
+            float deserialized = 0f;
+            serializer.TryDeserialize(data, ref deserialized).AssertSuccessWithoutWarnings();
+            Assert.AreEqual(float.PositiveInfinity, deserialized);
+        }
+
+        [Test]
+        public void VerifyNegativeInfinityRoundTrips() {
+            var serializer = new fsSerializer();
+
+            fsData data;
+            serializer.TrySerialize(float.NegativeInfinity, out data).AssertSuccessWithoutWarnings();
+            Assert.AreEqual("-Infinity", fsJsonPrinter.PrettyJson(data));
+
+            float deserialized = 0f;
+            serializer.TryDeserialize(data, ref deserialized).AssertSuccessWithoutWarnings();
+            Assert.AreEqual(float.NegativeInfinity, deserialized);
+        }
+
+        [Test]
+        public void VerifyMaxValueRoundTrips() {
+            var serializer = new fsSerializer();
+
+            fsData data;
+            serializer.TrySerialize(float.MaxValue, out data).AssertSuccessWithoutWarnings();
+            Assert.AreEqual(((double)float.MaxValue).ToString(System.Globalization.CultureInfo.InvariantCulture), fsJsonPrinter.PrettyJson(data));
+
+            float deserialized = 0f;
+            serializer.TryDeserialize(data, ref deserialized).AssertSuccessWithoutWarnings();
+            Assert.AreEqual(float.MaxValue, deserialized);
+        }
+
+        [Test]
+        public void VerifyMinValueRoundTrips() {
+            var serializer = new fsSerializer();
+
+            fsData data;
+            serializer.TrySerialize(float.MinValue, out data).AssertSuccessWithoutWarnings();
+            Assert.AreEqual(((double)float.MinValue).ToString(System.Globalization.CultureInfo.InvariantCulture), fsJsonPrinter.PrettyJson(data));
+
+            float deserialized = 0f;
+            serializer.TryDeserialize(data, ref deserialized).AssertSuccessWithoutWarnings();
+            Assert.AreEqual(float.MinValue, deserialized);
+        }
     }
 }


### PR DESCRIPTION
Fix exception when serializing float.NaN, and float infinities

Add tests to demonstrate fix

Fix #83