### PR TITLE
Early-out of serializable check if member is neither property nor field

### DIFF
--- a/Assets/FullSerializer/Source/Reflection/fsMetaType.cs
+++ b/Assets/FullSerializer/Source/Reflection/fsMetaType.cs
@@ -66,6 +66,11 @@ namespace FullSerializer {
                 PropertyInfo property = member as PropertyInfo;
                 FieldInfo field = member as FieldInfo;
 
+                // Early out if it's neither a field or a property, since we don't serialize anything else.
+                if (property == null && field == null) {
+                    continue;
+                }
+
                 // If an opt-in annotation is required, then skip the property if it doesn't have one
                 // of the serialize attributes
                 if (requireOptIn &&


### PR DESCRIPTION
I'm not sure how much time this saves really, but it definitely *should* be faster since it doesn't then go on to run LINQ on the member's attributes in the require opt-in or out cases.

All tests still pass after this change.

I won't be too cut up if this doesn't get accepted :)