### PR TITLE
.NET for WSA provide limited-level reflection functions.

### DIFF
--- a/Assets/FullSerializer/Source/Reflection/fsTypeCache.cs
+++ b/Assets/FullSerializer/Source/Reflection/fsTypeCache.cs
@@ -1,12 +1,15 @@
 ﻿using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.Reflection;
 
-namespace FullSerializer.Internal {
+namespace FullSerializer.Internal
+{
     /// <summary>
     /// Caches type name to type lookups. Type lookups occur in all loaded assemblies.
     /// </summary>
-    public static class fsTypeCache {
+    public static class fsTypeCache
+    {
         /// <summary>
         /// Cache from fully qualified type name to type instances.
         /// </summary>
@@ -23,18 +26,30 @@ namespace FullSerializer.Internal {
         /// </summary>
         private static List<Assembly> _assembliesByIndex;
 
-        static fsTypeCache() {
+        static fsTypeCache()
+        {
             // Setup assembly references so searching and the like resolves correctly.
             _assembliesByName = new Dictionary<string, Assembly>();
             _assembliesByIndex = new List<Assembly>();
 
 #if (!UNITY_EDITOR && UNITY_METRO && !ENABLE_IL2CPP) // no AppDomain on WinRT
+            
+            /*
+            //This wont work because we need all "loaded" assemblies not just one (this will just return the mscorlib.dll assembly)
             var assembly = typeof(object).GetTypeInfo().Assembly;
-            _assembliesByName[assembly.FullName] = assembly;
+            _assembliesByName.Add(assembly.FullName, assembly);
             _assembliesByIndex.Add(assembly);
+            */
+
+            foreach (Assembly assembly in GetAssemblies().Result)
+            {
+                _assembliesByName.Add(assembly.FullName, assembly);
+                _assembliesByIndex.Add(assembly);
+            }
 #else
-            foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies()) {
-                _assembliesByName[assembly.FullName] = assembly;
+            foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                _assembliesByName.Add(assembly.FullName, assembly);
                 _assembliesByIndex.Add(assembly);
             }
 #endif
@@ -47,11 +62,41 @@ namespace FullSerializer.Internal {
         }
 
 #if !(UNITY_WP8 || UNITY_METRO) // AssemblyLoad events are not supported on these platforms
-        private static void OnAssemblyLoaded(object sender, AssemblyLoadEventArgs args) {
-            _assembliesByName[args.LoadedAssembly.FullName] = args.LoadedAssembly;
+        private static void OnAssemblyLoaded(object sender, AssemblyLoadEventArgs args)
+        {
+			if (_assembliesByName.ContainsKey(args.LoadedAssembly.FullName))
+				return;
+
+			_assembliesByName.Add(args.LoadedAssembly.FullName, args.LoadedAssembly);
             _assembliesByIndex.Add(args.LoadedAssembly);
 
             _cachedTypes = new Dictionary<string, Type>();
+        }
+#endif
+
+#if (!UNITY_EDITOR && UNITY_METRO && !ENABLE_IL2CPP)
+        private static async System.Threading.Tasks.Task<List<Assembly>> GetAssemblies()
+        {
+            List<Assembly> assemblies = new List<Assembly>();
+
+            var files = await Windows.ApplicationModel.Package.Current.InstalledLocation.GetFilesAsync();
+            if (files == null)
+                return assemblies;
+
+            foreach (var file in files.Where(file => file.FileType == ".dll" || file.FileType == ".exe"))
+            {
+                try
+                {
+                    assemblies.Add(Assembly.Load(new AssemblyName(file.DisplayName)));
+                }
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Debug.WriteLine(ex.Message);
+                }
+
+            }
+
+            return assemblies;
         }
 #endif
 
@@ -63,10 +108,13 @@ namespace FullSerializer.Internal {
         /// <param name="typeName">The name of the type.</param>
         /// <param name="type">The found type.</param>
         /// <returns>True if the type was found, false otherwise.</returns>
-        private static bool TryDirectTypeLookup(string assemblyName, string typeName, out Type type) {
-            if (assemblyName != null) {
+        private static bool TryDirectTypeLookup(string assemblyName, string typeName, out Type type)
+        {
+            if (assemblyName != null)
+            {
                 Assembly assembly;
-                if (_assembliesByName.TryGetValue(assemblyName, out assembly)) {
+                if (_assembliesByName.TryGetValue(assemblyName, out assembly))
+                {
                     type = assembly.GetType(typeName, /*throwOnError:*/ false);
                     return type != null;
                 }
@@ -83,26 +131,31 @@ namespace FullSerializer.Internal {
         /// <param name="typeName">The name of the type.</param>
         /// <param name="type">The found type.</param>
         /// <returns>True if the type was found, false otherwise.</returns>
-        private static bool TryIndirectTypeLookup(string typeName, out Type type) {
+        private static bool TryIndirectTypeLookup(string typeName, out Type type)
+        {
             // There used to be a foreach loop through the value keys of the _assembliesByName
             // dictionary. However, during that loop assembly loads could occur, causing an
             // OutOfSync exception. To resolve that, we just iterate through the assemblies by
             // index.
 
             int i = 0;
-            while (i < _assembliesByIndex.Count) {
+            while (i < _assembliesByIndex.Count)
+            {
                 Assembly assembly = _assembliesByIndex[i];
 
                 // try GetType; should be fast
                 type = assembly.GetType(typeName);
-                if (type != null) {
+                if (type != null)
+                {
                     return true;
                 }
 
                 // private type or similar; go through the slow path and check every type's full
                 // name
-                foreach (var foundType in assembly.GetTypes()) {
-                    if (foundType.FullName == typeName) {
+                foreach (var foundType in assembly.GetTypes())
+                {
+                    if (foundType.FullName == typeName)
+                    {
                         type = foundType;
                         return true;
                     }
@@ -118,7 +171,8 @@ namespace FullSerializer.Internal {
         /// <summary>
         /// Removes any cached type lookup results.
         /// </summary>
-        public static void Reset() {
+        public static void Reset()
+        {
             _cachedTypes = new Dictionary<string, Type>();
         }
 
@@ -128,7 +182,8 @@ namespace FullSerializer.Internal {
         /// be found, then null will be returned.
         /// </summary>
         /// <param name="name">The fully qualified name of the type.</param>
-        public static Type GetType(string name) {
+        public static Type GetType(string name)
+        {
             return GetType(name, null);
         }
 
@@ -139,16 +194,20 @@ namespace FullSerializer.Internal {
         /// </summary>
         /// <param name="name">The fully qualified name of the type.</param>
         /// <param name="assemblyHint">A hint for the assembly to start the search with. Use null if unknown.</param>
-        public static Type GetType(string name, string assemblyHint) {
-            if (string.IsNullOrEmpty(name)) {
+        public static Type GetType(string name, string assemblyHint)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
                 return null;
             }
 
             Type type;
-            if (_cachedTypes.TryGetValue(name, out type) == false) {
+            if (_cachedTypes.TryGetValue(name, out type) == false)
+            {
                 // if both the direct and indirect type lookups fail, then throw an exception
                 if (TryDirectTypeLookup(assemblyHint, name, out type) == false &&
-                    TryIndirectTypeLookup(name, out type) == false) {
+                    TryIndirectTypeLookup(name, out type) == false)
+                {
                 }
 
                 _cachedTypes[name] = type;
@@ -158,4 +217,3 @@ namespace FullSerializer.Internal {
         }
     }
 }
-


### PR DESCRIPTION
This work-around looks for DLLs/Assemblies in the app-folder and loads them manually.
Cred to LuckyGeorge75 (reddit): https://goo.gl/yStvXD