### PR TITLE
Fix wrong path

### DIFF
--- a/BuildFiles/ProjectFiles/CommonData.csproj
+++ b/BuildFiles/ProjectFiles/CommonData.csproj
@@ -7,7 +7,7 @@
   	<UnityInstallFolder>C:\Program Files\Unity 5.0.0f4\Editor</UnityInstallFolder>
 
     <!-- This is the path, relative to this file, of the FullSerializer folder containing the "Source" directory -->
-    <FullSerializerFolder>..</FullSerializerFolder>
+    <FullSerializerFolder>..\..\Assets\FullSerializer</FullSerializerFolder>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
I was following the tutorial on how to create the dlls but it failed because of the wrong path to the source code.
Now the path is updated and it works again.