### PR TITLE
Allow fsIgnore to be applied to classes and structs to force all instances of those types to be ignored

### DIFF
--- a/Assets/FullSerializer/Source/Reflection/fsMetaType.cs
+++ b/Assets/FullSerializer/Source/Reflection/fsMetaType.cs
@@ -150,6 +150,11 @@ namespace FullSerializer {
                 return false;
             }
 
+            // Don't serialize members of types that themselves aren't to be serialized.
+            if (config.IgnoreSerializeTypeAttributes.Any(t => fsPortableReflection.HasAttribute(property.PropertyType, t))) {
+                return false;
+            }
+
             // If a property is annotated with one of the serializable
             // attributes, then it should it should definitely be serialized.
             //
@@ -190,6 +195,11 @@ namespace FullSerializer {
 
             // We don't serialize static fields
             if (field.IsStatic) {
+                return false;
+            }
+
+            // Don't serialize members of types that themselves aren't to be serialized.
+            if (config.IgnoreSerializeTypeAttributes.Any(t => fsPortableReflection.HasAttribute(field.FieldType, t))) {
                 return false;
             }
 

--- a/Assets/FullSerializer/Source/fsConfig.cs
+++ b/Assets/FullSerializer/Source/fsConfig.cs
@@ -47,6 +47,12 @@ namespace FullSerializer {
         public Type[] IgnoreSerializeAttributes = { typeof(NonSerializedAttribute), typeof(fsIgnoreAttribute) };
 
         /// <summary>
+        /// The attributes on a type that will force any fields or properties
+		/// of that type to *not* be serialized.
+        /// </summary>
+        public Type[] IgnoreSerializeTypeAttributes = { typeof(fsIgnoreAttribute) };
+
+        /// <summary>
         /// The default member serialization.
         /// </summary>
         public fsMemberSerialization DefaultMemberSerialization = fsMemberSerialization.Default;

--- a/Assets/FullSerializer/Source/fsIgnoreAttribute.cs
+++ b/Assets/FullSerializer/Source/fsIgnoreAttribute.cs
@@ -5,7 +5,7 @@ namespace FullSerializer {
     /// The given property or field annotated with [JsonIgnore] will not be
     /// serialized.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class | AttributeTargets.Struct)]
     public sealed class fsIgnoreAttribute : Attribute {
     }
 }

--- a/Assets/FullSerializer/Testing/Editor/IgnoreTypeTests.cs
+++ b/Assets/FullSerializer/Testing/Editor/IgnoreTypeTests.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace FullSerializer.Tests {
+    public class IgnoreTypeTests {
+        [fsIgnore]
+        private class IgnoredClass {
+        }
+        private class NotIgnoredClass {
+        }
+        [fsIgnore]
+        private struct IgnoredStruct {
+        }
+        private struct NotIgnoredStruct {
+        }
+        private class Model {
+            public IgnoredClass IgnoredClass;
+            public NotIgnoredClass NotIgnoredClass;
+            public IgnoredStruct IgnoredStruct;
+            public NotIgnoredStruct NotIgnoredStruct;
+        }
+
+        [Test]
+        public void TestSerializeReadOnlyProperty() {
+            var model = new Model();
+
+            fsData data;
+
+            var serializer = new fsSerializer();
+            Assert.IsTrue(serializer.TrySerialize(model, out data).Succeeded);
+
+            var expected = fsData.CreateDictionary();
+            expected.AsDictionary["NotIgnoredClass"] = new fsData();
+            expected.AsDictionary["NotIgnoredStruct"] = fsData.CreateDictionary();
+            Assert.AreEqual(expected, data);
+        }
+    }
+}

--- a/Assets/FullSerializer/Testing/Editor/IgnoreTypeTests.cs.meta
+++ b/Assets/FullSerializer/Testing/Editor/IgnoreTypeTests.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: fa9e814e86d3cf641acc4bb8546cc109
+timeCreated: 1484568717
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
My use case: I'm using FullSerializer to save game state. Some types in my game are *always* runtime-created, and will *always* require a pass to instantiate them after deserializing the game state. Rather than annotate every place these types are stored as members, it's much more convenient to annotate the type itself.

I've done this here by modifying `[fsIgnore]` to be allowed to be applied to classes and structs.