### PR TITLE
Fix types not deserializing when they have no public default constructor but an implicit static constructor

### DIFF
--- a/Assets/FullSerializer/Source/Internal/fsPortableReflection.cs
+++ b/Assets/FullSerializer/Source/Internal/fsPortableReflection.cs
@@ -199,6 +199,9 @@ namespace FullSerializer.Internal {
 
             for (int i = 0; i < ctors.Length; ++i) {
                 var ctor = ctors[i];
+
+                if (ctor.IsStatic) continue; // Ignore static constructors.
+
                 var ctorParams = ctor.GetParameters();
 
                 if (parameters.Length != ctorParams.Length) continue;

--- a/Assets/FullSerializer/Testing/Editor/ConstructorTests.cs
+++ b/Assets/FullSerializer/Testing/Editor/ConstructorTests.cs
@@ -1,0 +1,61 @@
+using NUnit.Framework;
+
+namespace FullSerializer.Tests {
+    public class ConstructorTests {
+        private class ClassWithNoPublicDefaultConstructor {
+            public int a = 1;
+
+            [fsIgnore]
+            public bool constructorCalled;
+
+            public ClassWithNoPublicDefaultConstructor(int dummy) {
+                a = 2;
+                constructorCalled = true;
+            }
+        }
+
+        [Test]
+        public void TestClassWithNoPublicDefaultConstructor() {
+            var serialized = fsData.CreateDictionary();
+            serialized.AsDictionary["a"] = new fsData(3);
+
+            var serializer = new fsSerializer();
+
+            ClassWithNoPublicDefaultConstructor result = null;
+            Assert.IsTrue(serializer.TryDeserialize(serialized, ref result).Succeeded);
+
+            // We expect the original value, but not for the constructor to have been called.
+            Assert.AreEqual(3, result.a);
+            Assert.IsFalse(result.constructorCalled);
+        }
+
+        private class ClassWithNoPublicDefaultConstructorButImplicitStatic {
+            public int a = 1;
+            public static int b = 2;
+
+            [fsIgnore]
+            public bool constructorCalled;
+
+            public ClassWithNoPublicDefaultConstructorButImplicitStatic(int dummy) {
+                a = 2;
+                constructorCalled = true;
+            }
+        }
+
+        [Test]
+        public void TestClassWithNoPublicDefaultConstructorButImplicitStatic() {
+            var serialized = fsData.CreateDictionary();
+            serialized.AsDictionary["a"] = new fsData(3);
+
+            var serializer = new fsSerializer();
+
+            ClassWithNoPublicDefaultConstructorButImplicitStatic result = null;
+            Assert.IsTrue(serializer.TryDeserialize(serialized, ref result).Succeeded);
+
+            // We expect the original value, but not for the constructor to have been called,
+            // DESPITE the presence of an implicit public static parameterless constructor.
+            Assert.AreEqual(3, result.a);
+            Assert.IsFalse(result.constructorCalled);
+        }
+    }
+}

--- a/Assets/FullSerializer/Testing/Editor/ConstructorTests.cs.meta
+++ b/Assets/FullSerializer/Testing/Editor/ConstructorTests.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: daaa047bf7621b34fa771d4b5343779f
+timeCreated: 1484837888
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
I encountered problems deserializing classes that look like this:

    class Test {
        public static int a;
        public Test(int dummy) {};
    }

... `fsMetaType` was attempting to use `Activator.CreateInstance` instead of `System.Runtime.Serialization.FormatterServices.GetSafeUninitializedObject` because the type is detected as having a public default constructor, which clearly isn't the case - the implicit static constructor is being seen instead!

I've just changed `GetDeclaredConstructor` ignore static constructors which works in my testing. I'm not sure of the wider impact.