### PR TITLE
Add config option to save DateTime and TimeOffset as Int64

### DIFF
--- a/Assets/FullSerializer/Source/fsConfig.cs
+++ b/Assets/FullSerializer/Source/fsConfig.cs
@@ -99,6 +99,12 @@ namespace FullSerializer {
         public string CustomDateTimeFormatString = null;
 
         /// <summary>
+        /// If true, DateTime and TimeSpan will be saved as 64 bit integers
+        /// rather than strings. DateTimeOffset will still be saved as string.
+        /// </summary>
+        public bool SerializeDateTimeAsInteger = false;
+
+        /// <summary>
         /// Int64 and UInt64 will be serialized and deserialized as string for
         /// compatibility
         /// </summary>

--- a/Assets/FullSerializer/Testing/Editor/DateTimeTests.cs
+++ b/Assets/FullSerializer/Testing/Editor/DateTimeTests.cs
@@ -1,14 +1,44 @@
 using System;
-using FullSerializer;
 using NUnit.Framework;
 
-public class DateTimeTests {
-    [Test]
-    public void StrangeFormatTests() {
-        var serializer = new fsSerializer();
-        DateTime time = DateTime.Now;
-        serializer.TryDeserialize(new fsData("2016-01-22T12:06:57.503005Z"), ref time).AssertSuccessWithoutWarnings();
+namespace FullSerializer.Tests {
+    public class DateTimeTests {
+        [Test]
+        public void StrangeFormatTests() {
+            var serializer = new fsSerializer();
+            DateTime time = DateTime.Now;
+            serializer.TryDeserialize(new fsData("2016-01-22T12:06:57.503005Z"), ref time).AssertSuccessWithoutWarnings();
 
-        Assert.AreEqual(Convert.ToDateTime("2016-01-22T12:06:57.503005Z"), time);
+            Assert.AreEqual(Convert.ToDateTime("2016-01-22T12:06:57.503005Z"), time);
+        }
+
+        [Test]
+        public void TestDateTimeAsIntIsInt() {
+            var serializer = new fsSerializer {Config = {SerializeDateTimeAsInteger = true}};
+
+            var original = new DateTime(1985, 8, 22, 4, 19, 01, 123, DateTimeKind.Utc);
+            fsData serializedData;
+            serializer.TrySerialize(original, out serializedData).AssertSuccessWithoutWarnings();
+
+            Assert.That(serializedData.IsInt64);
+        }
+
+        [Test]
+        public void TestDateTimeAsIntRoundTrips() {
+            var serializer = new fsSerializer {Config = {SerializeDateTimeAsInteger = true}};
+
+            var original = new DateTime(1985, 8, 22, 4, 19, 01, 123, DateTimeKind.Utc);
+            var deserialized = Clone(original, serializer, serializer);
+
+            Assert.AreEqual(original, deserialized);
+        }
+
+        public static T Clone<T>(T original, fsSerializer serializer, fsSerializer deserializer) {
+            fsData serializedData;
+            serializer.TrySerialize(original, out serializedData).AssertSuccessWithoutWarnings();
+            var actual = default(T);
+            deserializer.TryDeserialize(serializedData, ref actual);
+            return actual;
+        }
     }
 }


### PR DESCRIPTION
This is something I did a long time ago, to make date serialization faster and take less space once serialized.

It's not pretty code but it works - I'll leave it up to you to decide if it can be merged or not, or if it needs rework!

Edit: re-pushed with new formatting and tests namespace.