### PR TITLE
Add config option to deserialize strings as numbers

### DIFF
--- a/Assets/FullSerializer/Source/Converters/fsPrimitiveConverter.cs
+++ b/Assets/FullSerializer/Source/Converters/fsPrimitiveConverter.cs
@@ -104,8 +104,10 @@ namespace FullSerializer.Internal {
                 else if (storage.IsInt64) {
                     instance = Convert.ChangeType(storage.AsInt64, storageType);
                 }
-                else if (Serializer.Config.Serialize64BitIntegerAsString && storage.IsString &&
-                    (storageType == typeof(Int64) || storageType == typeof(UInt64))) {
+                else if (storage.IsString &&
+                    (Serializer.Config.Serialize64BitIntegerAsString && (storageType == typeof(Int64) || storageType == typeof(UInt64)) ||
+                    Serializer.Config.CoerceStringsToNumbers))
+                {
                     instance = Convert.ChangeType(storage.AsString, storageType);
                 }
                 else {

--- a/Assets/FullSerializer/Source/fsConfig.cs
+++ b/Assets/FullSerializer/Source/fsConfig.cs
@@ -105,6 +105,12 @@ namespace FullSerializer {
         public bool Serialize64BitIntegerAsString = false;
 
         /// <summary>
+        /// Strings will be converted to numbers if nessesary
+        /// compatibility
+        /// </summary>
+        public bool CoerceStringsToNumbers = false;
+
+        /// <summary>
         /// Enums are serialized using their names by default. Setting this to
         /// true will serialize them as integers instead.
         /// </summary>


### PR DESCRIPTION
I'm dealing with JSON generated by an API that sometimes formats numbers as numbers, and other times formats them as strings. It is hugely helpful to be able to ask the serializer to take care of this for me, instead of writing converter code for every type I deal with.